### PR TITLE
Access ClickHouse via HTTPS instead of HTTP (default)

### DIFF
--- a/packages/clickhouse/src/index.js
+++ b/packages/clickhouse/src/index.js
@@ -9,6 +9,7 @@ const ch = new ClickHouse({
   port: process.env.CH_PORT,
   user: process.env.CH_USER,
   password: process.env.CH_PASSWORD,
+  protocol: "https",
 });
 
 module.exports = {


### PR DESCRIPTION
Close #294.

<a href="https://gitpod-staging.com/#https://github.com/mikenikles/your-analytics/pull/295"><img src="https://gitpod-staging.com/button/open-in-gitpod.svg"/></a>

